### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,6 @@ on: [push, workflow_dispatch]
 
 permissions:
   contents: read
-  gist: write
 
 jobs:
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,10 @@ name: Test
 
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+  gist: write
+
 jobs:
   build:
     name: Test on ${{ matrix.os }} / ${{ matrix.arch }}


### PR DESCRIPTION
Potential fix for [https://github.com/qrdl/testaroli/security/code-scanning/1](https://github.com/qrdl/testaroli/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions performed in the workflow:
- `contents: read` is required for basic repository access.
- `gist: write` is required for updating the gist with the badge.
- Other permissions should not be granted unless explicitly needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or at the job level for more granular control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
